### PR TITLE
Fixed: yarn install error

### DIFF
--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -38,7 +38,10 @@ rl.question(
     console.log(
       `Installing dependencies for ${projectName} using ${packageManager}`
     );
-    const installCommand = `cd ${projectName} && rm -rf yarn.lock && ${packageManager} install`;
+    const defaultCommand = `cd ${projectName} && ${packageManager} install`;
+    const otherCommand = `cd ${projectName} && rm -rf yarn.lock .yarn .yarnrc.yml && ${packageManager} install`;
+    const installCommand =
+      packageManager === 'yarn' ? defaultCommand : otherCommand;
     const installedDeps = runCommand(installCommand);
     if (!installedDeps) process.exit();
     rl.close();


### PR DESCRIPTION
I added if statement to divide yarn command and other commands.

```ts
const defaultCommand = `cd ${projectName} && ${packageManager} install`;
const otherCommand = `cd ${projectName} && rm -rf yarn.lock .yarn .yarnrc.yml && ${packageManager} install`;
const installCommand = packageManager === 'yarn' ? defaultCommand : otherCommand;
```